### PR TITLE
refactor: add backend arg to `VisModel.has_adaptor()` and rename to `has_backend_adaptor()`

### DIFF
--- a/src/microvis/core/_vis_model.py
+++ b/src/microvis/core/_vis_model.py
@@ -85,11 +85,15 @@ class VisModel(ModelBase, Generic[AdaptorType]):
     # see `examples/custom_node.py` for an example of how this is used.
     BACKEND_ADAPTORS: ClassVar[Dict[str, Type[BackendAdaptor]]]
 
-    @property
-    def has_adaptor(self) -> bool:
-        """Return True if the object has a backend adaptor."""
-        # TODO: this might need to turn into a method that accepts a backend name
-        return bool(self._backend_adaptors)
+    def has_adaptor(self, backend: str | None = None) -> bool:
+        """Return True if the object has a backend adaptor.
+
+        If None is passed, the returned bool indicates the presence of any
+        adaptor class.
+        """
+        if backend is None:
+            return bool(self._backend_adaptors)
+        return backend in self._backend_adaptors
 
     def backend_adaptor(self, backend: str | None = None) -> AdaptorType:
         """Get the backend adaptor for this object. Creates one if it doesn't exist.
@@ -151,7 +155,7 @@ class VisModel(ModelBase, Generic[AdaptorType]):
 
     def _on_any_event(self, info: EmissionInfo) -> None:
         signal_name = info.signal.name
-        if not self.has_adaptor or signal_name not in self._evented_fields:
+        if signal_name not in self._evented_fields:
             return
 
         # NOTE: this loop runs anytime any attribute on any model is changed...

--- a/src/microvis/core/_vis_model.py
+++ b/src/microvis/core/_vis_model.py
@@ -86,7 +86,7 @@ class VisModel(ModelBase, Generic[AdaptorType]):
     # see `examples/custom_node.py` for an example of how this is used.
     BACKEND_ADAPTORS: ClassVar[Dict[str, Type[BackendAdaptor]]]
 
-    def has_adaptor(self, backend: str | None = None) -> bool:
+    def has_backend_adaptor(self, backend: str | None = None) -> bool:
         """Return True if the object has a backend adaptor.
 
         If None is passed, the returned bool indicates the presence of any

--- a/src/microvis/core/_vis_model.py
+++ b/src/microvis/core/_vis_model.py
@@ -68,7 +68,8 @@ class VisModel(ModelBase, Generic[AdaptorType]):
     the given backend.
     """
 
-    # Really, this should be `_backend: ClassVar[dict[str, T]]``, but thats a type error
+    # Really, this should be `_backend_adaptors: ClassVar[dict[str, T]]``,
+    # but thats a type error.
     # PEP 526 states that ClassVar cannot include any type variables...
     # but there is discussion that this might be too limiting.
     # dicsussion: https://github.com/python/mypy/issues/5144

--- a/src/microvis/core/canvas.py
+++ b/src/microvis/core/canvas.py
@@ -76,7 +76,7 @@ class Canvas(VisModel[CanvasAdaptorProtocol]):
 
     def close(self) -> None:
         """Close the canvas."""
-        if self.has_adaptor:
+        if self.has_adaptor():
             self.backend_adaptor()._vis_close()
 
     # show and render will trigger a backend connection
@@ -101,7 +101,7 @@ class Canvas(VisModel[CanvasAdaptorProtocol]):
         # method (see, for example, the View._create_backend method)
         self.backend_adaptor(backend=backend)  # make sure we have a backend adaptor
         for view in self.views:
-            if not view.has_adaptor:
+            if not view.has_adaptor():
                 # make sure all of the views have a backend adaptor
                 view.backend_adaptor(backend=backend)
         self.visible = True
@@ -127,7 +127,7 @@ class Canvas(VisModel[CanvasAdaptorProtocol]):
             raise TypeError("view must be an instance of View")
 
         self.views.append(view)
-        if self.has_adaptor:
+        if self.has_adaptor():
             self.backend_adaptor()._vis_add_view(view)
 
         return view

--- a/src/microvis/core/canvas.py
+++ b/src/microvis/core/canvas.py
@@ -76,7 +76,7 @@ class Canvas(VisModel[CanvasAdaptorProtocol]):
 
     def close(self) -> None:
         """Close the canvas."""
-        if self.has_adaptor():
+        if self.has_backend_adaptor():
             self.backend_adaptor()._vis_close()
 
     # show and render will trigger a backend connection
@@ -101,7 +101,7 @@ class Canvas(VisModel[CanvasAdaptorProtocol]):
         # method (see, for example, the View._create_backend method)
         self.backend_adaptor(backend=backend)  # make sure we have a backend adaptor
         for view in self.views:
-            if not view.has_adaptor():
+            if not view.has_backend_adaptor():
                 # make sure all of the views have a backend adaptor
                 view.backend_adaptor(backend=backend)
         self.visible = True
@@ -127,7 +127,7 @@ class Canvas(VisModel[CanvasAdaptorProtocol]):
             raise TypeError("view must be an instance of View")
 
         self.views.append(view)
-        if self.has_adaptor():
+        if self.has_backend_adaptor():
             self.backend_adaptor()._vis_add_view(view)
 
         return view

--- a/src/microvis/core/nodes/_data.py
+++ b/src/microvis/core/nodes/_data.py
@@ -66,7 +66,7 @@ class DataNode(Node[DataNodeBackendT]):
     def _on_data_changed(self) -> None:
         # Note: could accept an EmissionInfo argument here and gate the
         # update on event types.
-        if self.has_adaptor:
+        if self.has_adaptor():
             self.backend_adaptor()._vis_set_data(cast(ArrayLike, self.data_raw))
 
     @property
@@ -77,7 +77,7 @@ class DataNode(Node[DataNodeBackendT]):
         return cast("ArrayLike", self._data.__wrapped__)
 
     def _on_any_event(self, info: EmissionInfo) -> None:
-        if not self.has_adaptor:
+        if not self.has_adaptor():
             return
 
         # if the event is coming from a DataField, make

--- a/src/microvis/core/nodes/_data.py
+++ b/src/microvis/core/nodes/_data.py
@@ -66,7 +66,7 @@ class DataNode(Node[DataNodeBackendT]):
     def _on_data_changed(self) -> None:
         # Note: could accept an EmissionInfo argument here and gate the
         # update on event types.
-        if self.has_adaptor():
+        if self.has_backend_adaptor():
             self.backend_adaptor()._vis_set_data(cast(ArrayLike, self.data_raw))
 
     @property
@@ -77,7 +77,7 @@ class DataNode(Node[DataNodeBackendT]):
         return cast("ArrayLike", self._data.__wrapped__)
 
     def _on_any_event(self, info: EmissionInfo) -> None:
-        if not self.has_adaptor():
+        if not self.has_backend_adaptor():
             return
 
         # if the event is coming from a DataField, make

--- a/src/microvis/core/nodes/node.py
+++ b/src/microvis/core/nodes/node.py
@@ -114,7 +114,7 @@ class Node(VisModel[NodeAdaptorProtocolTypeCoV]):
         if node not in self.children:
             logger.debug(f"Adding node {nd} to {slf}")
             self.children.append(node)
-            if self.has_adaptor():
+            if self.has_backend_adaptor():
                 self.backend_adaptor()._vis_add_node(node)
 
     @classmethod

--- a/src/microvis/core/nodes/node.py
+++ b/src/microvis/core/nodes/node.py
@@ -114,7 +114,7 @@ class Node(VisModel[NodeAdaptorProtocolTypeCoV]):
         if node not in self.children:
             logger.debug(f"Adding node {nd} to {slf}")
             self.children.append(node)
-            if self.has_adaptor:
+            if self.has_adaptor():
                 self.backend_adaptor()._vis_add_node(node)
 
     @classmethod

--- a/src/microvis/core/view.py
+++ b/src/microvis/core/view.py
@@ -138,7 +138,7 @@ class View(Node[ViewAdaptorProtocol]):
     def add_node(self, node: NodeType) -> NodeType:
         """Add any node to the scene."""
         self.scene.add(node)
-        if self.camera.has_adaptor:
+        if self.camera.has_adaptor():
             # FIXME!: put this vispy specific API elsewhere
             # i guess we need a reset_range type API
             self.camera.native.set_range(margin=0)

--- a/src/microvis/core/view.py
+++ b/src/microvis/core/view.py
@@ -138,7 +138,7 @@ class View(Node[ViewAdaptorProtocol]):
     def add_node(self, node: NodeType) -> NodeType:
         """Add any node to the scene."""
         self.scene.add(node)
-        if self.camera.has_adaptor():
+        if self.camera.has_backend_adaptor():
             # FIXME!: put this vispy specific API elsewhere
             # i guess we need a reset_range type API
             self.camera.native.set_range(margin=0)

--- a/tests/test_backend/test_vispy_qt/test_microvis.py
+++ b/tests/test_backend/test_vispy_qt/test_microvis.py
@@ -26,18 +26,18 @@ def test_canvas(qtbot: "QtBot") -> None:
     assert isinstance(image, Image)
     np.testing.assert_array_equal(image.data, data)
 
-    assert not canvas.has_adaptor(backend="vispy")
-    assert not view.has_adaptor(backend="vispy")
-    assert not camera.has_adaptor(backend="vispy")
+    assert not canvas.has_backend_adaptor(backend="vispy")
+    assert not view.has_backend_adaptor(backend="vispy")
+    assert not camera.has_backend_adaptor(backend="vispy")
 
     canvas.show(backend="vispy")
     vispy_canvas = canvas.native
     qtbot.addWidget(vispy_canvas.native)
 
-    assert canvas.has_adaptor(backend="vispy")
-    assert view.has_adaptor(backend="vispy")
-    assert camera.has_adaptor(backend="vispy")
-    assert image.has_adaptor(backend="vispy")
+    assert canvas.has_backend_adaptor(backend="vispy")
+    assert view.has_backend_adaptor(backend="vispy")
+    assert camera.has_backend_adaptor(backend="vispy")
+    assert image.has_backend_adaptor(backend="vispy")
 
     canvas.dict()
     view.dict()

--- a/tests/test_backend/test_vispy_qt/test_microvis.py
+++ b/tests/test_backend/test_vispy_qt/test_microvis.py
@@ -26,18 +26,18 @@ def test_canvas(qtbot: "QtBot") -> None:
     assert isinstance(image, Image)
     np.testing.assert_array_equal(image.data, data)
 
-    assert not canvas.has_adaptor
-    assert not view.has_adaptor
-    assert not camera.has_adaptor
+    assert not canvas.has_adaptor(backend="vispy")
+    assert not view.has_adaptor(backend="vispy")
+    assert not camera.has_adaptor(backend="vispy")
 
     canvas.show(backend="vispy")
     vispy_canvas = canvas.native
     qtbot.addWidget(vispy_canvas.native)
 
-    assert canvas.has_adaptor
-    assert view.has_adaptor
-    assert camera.has_adaptor
-    assert image.has_adaptor
+    assert canvas.has_adaptor(backend="vispy")
+    assert view.has_adaptor(backend="vispy")
+    assert camera.has_adaptor(backend="vispy")
+    assert image.has_adaptor(backend="vispy")
 
     canvas.dict()
     view.dict()

--- a/tests/test_core/test_canvas.py
+++ b/tests/test_core/test_canvas.py
@@ -13,11 +13,11 @@ def test_canvas(mock_backend) -> None:
     assert canvas.background_color and canvas.background_color.as_named() == "red"
 
     # before show() is called, the backend should not be created
-    assert not canvas.has_adaptor
+    assert not canvas.has_adaptor()
 
     # once show() is called, the backend should be created and visible called
     canvas.show()
-    assert canvas.has_adaptor
+    assert canvas.has_adaptor()
     adaptor = canvas.backend_adaptor()
     adaptor._vis_set_visible.assert_called_once_with(True)
 

--- a/tests/test_core/test_canvas.py
+++ b/tests/test_core/test_canvas.py
@@ -13,11 +13,11 @@ def test_canvas(mock_backend) -> None:
     assert canvas.background_color and canvas.background_color.as_named() == "red"
 
     # before show() is called, the backend should not be created
-    assert not canvas.has_adaptor()
+    assert not canvas.has_backend_adaptor()
 
     # once show() is called, the backend should be created and visible called
     canvas.show()
-    assert canvas.has_adaptor()
+    assert canvas.has_backend_adaptor()
     adaptor = canvas.backend_adaptor()
     adaptor._vis_set_visible.assert_called_once_with(True)
 

--- a/tests/test_core/test_view.py
+++ b/tests/test_core/test_view.py
@@ -12,12 +12,12 @@ def test_view(mock_backend) -> None:
     assert view.background_color and view.background_color.as_named() == "red"
 
     # before show() is called, the backend should not be created
-    assert not view.has_adaptor
+    assert not view.has_adaptor()
     assert not mock_backend
 
     # once show() is called, the backend should be created and visible called
     view.show()
-    assert view.has_adaptor
+    assert view.has_adaptor()
     adaptor = view.backend_adaptor()
     assert view.visible
     adaptor._vis_set_camera.assert_called_once()

--- a/tests/test_core/test_view.py
+++ b/tests/test_core/test_view.py
@@ -12,12 +12,12 @@ def test_view(mock_backend) -> None:
     assert view.background_color and view.background_color.as_named() == "red"
 
     # before show() is called, the backend should not be created
-    assert not view.has_adaptor()
+    assert not view.has_backend_adaptor()
     assert not mock_backend
 
     # once show() is called, the backend should be created and visible called
     view.show()
-    assert view.has_adaptor()
+    assert view.has_backend_adaptor()
     adaptor = view.backend_adaptor()
     assert view.visible
     adaptor._vis_set_camera.assert_called_once()


### PR DESCRIPTION
Saw a note about this needing to be done so did and refactored to bring it in line with the `backend_adaptor()` method